### PR TITLE
#26: BREAKING CHANGE: switch to official node ids

### DIFF
--- a/src/serlio/prtMaterial/ArnoldMaterialNode.cpp
+++ b/src/serlio/prtMaterial/ArnoldMaterialNode.cpp
@@ -18,15 +18,16 @@
  */
 
 #include "prtMaterial/ArnoldMaterialNode.h"
-
-#include "prt/StringUtils.h"
-
 #include "prtMaterial/MaterialInfo.h"
 
 #include "util/MArrayWrapper.h"
 #include "util/MELScriptBuilder.h"
 #include "util/MItDependencyNodesWrapper.h"
 #include "util/MayaUtilities.h"
+
+#include "serlioPlugin.h"
+
+#include "prt/StringUtils.h"
 
 #include "maya/MFnGenericAttribute.h"
 #include "maya/MFnMesh.h"
@@ -41,7 +42,8 @@
 #include <list>
 #include <sstream>
 
-MTypeId ArnoldMaterialNode::id(0x12345);
+MTypeId ArnoldMaterialNode::id(SerlioNodeIDs::SERLIO_PREFIX,
+	                           SerlioNodeIDs::ARNOLD_MATERIAL_NODE);
 
 MObject ArnoldMaterialNode::aInMesh;
 MObject ArnoldMaterialNode::aOutMesh;

--- a/src/serlio/prtMaterial/PRTMaterialNode.cpp
+++ b/src/serlio/prtMaterial/PRTMaterialNode.cpp
@@ -28,6 +28,8 @@
 #include "util/MayaUtilities.h"
 #include "util/MItDependencyNodesWrapper.h"
 
+#include "serlioPlugin.h"
+
 #include "prt/StringUtils.h"
 
 #include "maya/MGlobal.h"
@@ -50,7 +52,8 @@ constexpr bool DBG = false;
 
 } // namespace
 
-MTypeId PRTMaterialNode::id(PRT_MATERIAL_TYPE_ID);
+MTypeId PRTMaterialNode::id(SerlioNodeIDs::SERLIO_PREFIX,
+                            SerlioNodeIDs::STRINGRAY_MATERIAL_NODE);
 
 MObject	PRTMaterialNode::aInMesh;
 MObject PRTMaterialNode::aOutMesh;

--- a/src/serlio/prtMaterial/PRTMaterialNode.h
+++ b/src/serlio/prtMaterial/PRTMaterialNode.h
@@ -33,8 +33,6 @@
 #include <algorithm>
 
 
-#define PRT_MATERIAL_TYPE_ID 0x8667b
-
 class MaterialColor;
 
 class PRTMaterialNode : public MPxNode {

--- a/src/serlio/prtModifier/PRTModifierNode.cpp
+++ b/src/serlio/prtModifier/PRTModifierNode.cpp
@@ -22,6 +22,8 @@
 #include "util/Utilities.h"
 #include "util/MayaUtilities.h"
 
+#include "serlioPlugin.h"
+
 #include "maya/MDataHandle.h"
 #include "maya/MFnTypedAttribute.h"
 #include "maya/MFnMeshData.h"
@@ -42,7 +44,8 @@ namespace {
 }
 
 // Unique Node TypeId
-MTypeId PRTModifierNode::id(0x00085000);
+MTypeId PRTModifierNode::id(SerlioNodeIDs::SERLIO_PREFIX,
+                            SerlioNodeIDs::PRT_GEOMETRY_NODE);
 MObject PRTModifierNode::rulePkg;
 MObject PRTModifierNode::currentRulePkg;
 MObject PRTModifierNode::mRandomSeed;

--- a/src/serlio/serlioPlugin.h
+++ b/src/serlio/serlioPlugin.h
@@ -19,12 +19,24 @@
 
 #pragma once
 
+#include <cstdint>
+
 #ifdef _WIN32
-#	ifdef SRL_TEST_EXPORTS
-#		define SRL_TEST_EXPORTS_API __declspec(dllexport)
-#	else
-#		define SRL_TEST_EXPORTS_API
-#	endif
+#   ifdef SRL_TEST_EXPORTS
+#      define SRL_TEST_EXPORTS_API __declspec(dllexport)
+#   else
+#      define SRL_TEST_EXPORTS_API
+#   endif
 #else
-#	define SRL_TEST_EXPORTS_API __attribute__ ((visibility ("default")))
+#   define SRL_TEST_EXPORTS_API __attribute__ ((visibility ("default")))
 #endif
+
+namespace SerlioNodeIDs {
+
+// our registered node id range is: 0x00132980 - 0x001329bf
+constexpr std::uint32_t SERLIO_PREFIX           = 0x00132980;
+constexpr std::uint32_t PRT_GEOMETRY_NODE       = 0x5;
+constexpr std::uint32_t STRINGRAY_MATERIAL_NODE = 0xA;
+constexpr std::uint32_t ARNOLD_MATERIAL_NODE    = 0xF;
+
+} // namespace SerlioNodeIDs


### PR DESCRIPTION
with this change, scenes (mb) from will open with invalid serlio modifier nodes and very likely be unusable.