### PR TITLE
#63: move plugin dependency checks out of initialization phase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
-/src/cmake-*
 /build*
 /install
+
+# ignore CLion project files
+/src/cmake-*
 /**/.idea
+
+# ignore Visual Studio solution files
+/**/.vs
 /src/CMakeSettings.json
-/.vs
+/src/out*

--- a/src/serlio/serlioPlugin.h
+++ b/src/serlio/serlioPlugin.h
@@ -20,8 +20,8 @@
 #pragma once
 
 #include <cstdint>
-#include <vector>
 #include <string>
+#include <vector>
 
 #ifdef _WIN32
 #	ifdef SRL_TEST_EXPORTS

--- a/src/serlio/serlioPlugin.h
+++ b/src/serlio/serlioPlugin.h
@@ -20,6 +20,8 @@
 #pragma once
 
 #include <cstdint>
+#include <vector>
+#include <string>
 
 #ifdef _WIN32
 #	ifdef SRL_TEST_EXPORTS
@@ -40,3 +42,10 @@ constexpr std::uint32_t STRINGRAY_MATERIAL_NODE = 0xA;
 constexpr std::uint32_t ARNOLD_MATERIAL_NODE = 0xF;
 
 } // namespace SerlioNodeIDs
+
+namespace MayaPluginUtilities {
+
+// defined here because of limitations of including MFnPlugin.h multiple times
+bool pluginDependencyCheck(const std::vector<std::string>& dependencies);
+
+} // namespace MayaPluginUtilities

--- a/src/serlio/util/Utilities.cpp
+++ b/src/serlio/util/Utilities.cpp
@@ -30,18 +30,15 @@ struct IUnknown;
 #	include <windows.h>
 #	include <shellapi.h>
 #else
-#	include <ftw.h>
-#	include <unistd.h>
 #	include <dlfcn.h>
+#	include <unistd.h>
 #endif
 
 #include <cwchar>
-#include <memory>
 #include <sstream>
 #include <stdexcept>
 #include <string>
 #include <sys/stat.h>
-#include <sys/types.h>
 
 namespace prtu {
 

--- a/src/serlio/util/Utilities.cpp
+++ b/src/serlio/util/Utilities.cpp
@@ -28,6 +28,7 @@
 struct IUnknown;
 #	include <process.h>
 #	include <windows.h>
+#	include <shellapi.h>
 #else
 #	include <ftw.h>
 #	include <unistd.h>


### PR DESCRIPTION
The plugin load order is (practically) undefined, therefore we must not check the presence of e.g. shaderFX at Serlio initialization time.

Calling findPlugin once per compute is a compromise, we should actually call it every time (user can unload other plugins at any time) but that's overkill.

Maya shows a strong warning dialog if the user tries to unload a dependency plugin which has nodes in use by the current scene.

Also added check for "mtoa" (arnold) to the ArnoldMaterialNode::compute