### PR TITLE
fix cleanup regression

### DIFF
--- a/src/serlio/modifiers/MayaCallbacks.cpp
+++ b/src/serlio/modifiers/MayaCallbacks.cpp
@@ -164,68 +164,6 @@ void assignVertexNormals(MFnMesh& mFnMesh, MIntArray& mayaFaceCounts, MIntArray&
 	MCHECK(mFnMesh.setFaceVertexNormals(expandedNormals, faceList, mayaVertexIndices));
 }
 
-constexpr unsigned int maxStringLength = 400;
-constexpr unsigned int maxFloatArrayLength = 5;
-constexpr unsigned int maxStringArrayLength = 2;
-
-adsk::Data::Structure* getMaterialDataStructure(const prt::AttributeMap** materials, size_t faceRangesSize) {
-	adsk::Data::Structure* fStructure = adsk::Data::Structure::structureByName(PRT_MATERIAL_STRUCTURE.c_str());
-	if ((fStructure == nullptr) && (materials != nullptr) && (faceRangesSize > 1)) {
-		const prt::AttributeMap* mat = materials[0];
-
-		// Register our structure since it is not registered yet.
-		fStructure = adsk::Data::Structure::create();
-		fStructure->setName(PRT_MATERIAL_STRUCTURE.c_str());
-
-		fStructure->addMember(adsk::Data::Member::kInt32, 1, PRT_MATERIAL_FACE_INDEX_START.c_str());
-		fStructure->addMember(adsk::Data::Member::kInt32, 1, PRT_MATERIAL_FACE_INDEX_END.c_str());
-
-		size_t keyCount = 0;
-		wchar_t const* const* keys = mat->getKeys(&keyCount);
-		for (int k = 0; k < keyCount; k++) {
-			wchar_t const* key = keys[k];
-
-			adsk::Data::Member::eDataType type;
-			unsigned int size = 0;
-			unsigned int arrayLength = 1;
-
-			// clang-format off
-			switch (mat->getType(key)) {
-				case prt::Attributable::PT_BOOL: type = adsk::Data::Member::kBoolean; size = 1;  break;
-				case prt::Attributable::PT_FLOAT: type = adsk::Data::Member::kDouble; size = 1; break;
-				case prt::Attributable::PT_INT: type = adsk::Data::Member::kInt32; size = 1; break;
-
-				// workaround: using kString type crashes maya when setting metadata elements. Therefore we use array of kUInt8
-				case prt::Attributable::PT_STRING: type = adsk::Data::Member::kUInt8; size = maxStringLength;  break;
-				case prt::Attributable::PT_BOOL_ARRAY: type = adsk::Data::Member::kBoolean; size = maxStringLength; break;
-				case prt::Attributable::PT_INT_ARRAY: type = adsk::Data::Member::kInt32; size = maxStringLength; break;
-				case prt::Attributable::PT_FLOAT_ARRAY: type = adsk::Data::Member::kDouble; size = maxFloatArrayLength; break;
-				case prt::Attributable::PT_STRING_ARRAY: type = adsk::Data::Member::kUInt8; size = maxStringLength; arrayLength = maxStringArrayLength; break;
-
-				case prt::Attributable::PT_UNDEFINED: break;
-				case prt::Attributable::PT_BLIND_DATA: break;
-				case prt::Attributable::PT_BLIND_DATA_ARRAY: break;
-				case prt::Attributable::PT_COUNT: break;
-			}
-			// clang-format on
-
-			if (size > 0) {
-				for (unsigned int i = 0; i < arrayLength; i++) {
-					std::wstring keyToUse = key;
-					if (i > 0)
-						keyToUse = key + std::to_wstring(i);
-					const std::string keyToUseNarrow = prtu::toOSNarrowFromUTF16(keyToUse);
-					fStructure->addMember(type, size, keyToUseNarrow.c_str());
-				}
-			}
-		}
-
-		adsk::Data::Structure::registerStructure(*fStructure);
-	}
-
-	return fStructure;
-}
-
 } // namespace
 
 void MayaCallbacks::addMesh(const wchar_t*, const double* vtx, size_t vtxSize, const double* nrm, size_t nrmSize,
@@ -266,6 +204,66 @@ void MayaCallbacks::addMesh(const wchar_t*, const double* vtx, size_t vtxSize, c
 	MFnMesh outputMesh(outMeshObj);
 	outputMesh.copyInPlace(oMesh);
 
+	// create material metadata
+	constexpr unsigned int maxStringLength = 400;
+	constexpr unsigned int maxFloatArrayLength = 5;
+	constexpr unsigned int maxStringArrayLength = 2;
+
+	adsk::Data::Structure* fStructure; // Structure to use for creation
+	fStructure = adsk::Data::Structure::structureByName(PRT_MATERIAL_STRUCTURE.c_str());
+	if ((fStructure == nullptr) && (materials != nullptr) && (faceRangesSize > 1)) {
+		const prt::AttributeMap* mat = materials[0];
+
+		// Register our structure since it is not registered yet.
+		fStructure = adsk::Data::Structure::create();
+		fStructure->setName(PRT_MATERIAL_STRUCTURE.c_str());
+
+		fStructure->addMember(adsk::Data::Member::kInt32, 1, PRT_MATERIAL_FACE_INDEX_START.c_str());
+		fStructure->addMember(adsk::Data::Member::kInt32, 1, PRT_MATERIAL_FACE_INDEX_END.c_str());
+
+		size_t keyCount = 0;
+		wchar_t const* const* keys = mat->getKeys(&keyCount);
+		for (int k = 0; k < keyCount; k++) {
+			wchar_t const* key = keys[k];
+
+			adsk::Data::Member::eDataType type;
+			unsigned int size = 0;
+			unsigned int arrayLength = 1;
+
+			// clang-format off
+			switch (mat->getType(key)) {
+				case prt::Attributable::PT_BOOL: type = adsk::Data::Member::kBoolean; size = 1;  break;
+				case prt::Attributable::PT_FLOAT: type = adsk::Data::Member::kDouble; size = 1; break;
+				case prt::Attributable::PT_INT: type = adsk::Data::Member::kInt32; size = 1; break;
+
+				//workaround: using kString type crashes maya when setting metadata elememts. Therefore we use array of kUInt8
+				case prt::Attributable::PT_STRING: type = adsk::Data::Member::kUInt8; size = maxStringLength;  break;
+				case prt::Attributable::PT_BOOL_ARRAY: type = adsk::Data::Member::kBoolean; size = maxStringLength; break;
+				case prt::Attributable::PT_INT_ARRAY: type = adsk::Data::Member::kInt32; size = maxStringLength; break;
+				case prt::Attributable::PT_FLOAT_ARRAY: type = adsk::Data::Member::kDouble; size = maxFloatArrayLength; break;
+				case prt::Attributable::PT_STRING_ARRAY: type = adsk::Data::Member::kUInt8; size = maxStringLength; arrayLength = maxStringArrayLength; break;
+
+				case prt::Attributable::PT_UNDEFINED: break;
+				case prt::Attributable::PT_BLIND_DATA: break;
+				case prt::Attributable::PT_BLIND_DATA_ARRAY: break;
+				case prt::Attributable::PT_COUNT: break;
+			}
+			// clang-format on
+
+			if (size > 0) {
+				for (unsigned int i = 0; i < arrayLength; i++) {
+					std::wstring keyToUse = key;
+					if (i > 0)
+						keyToUse = key + std::to_wstring(i);
+					const std::string keyToUseNarrow = prtu::toOSNarrowFromUTF16(keyToUse);
+					fStructure->addMember(type, size, keyToUseNarrow.c_str());
+				}
+			}
+		}
+
+		adsk::Data::Structure::registerStructure(*fStructure);
+	}
+
 	MCHECK(stat);
 	MFnMesh inputMesh(inMeshObj);
 
@@ -273,7 +271,6 @@ void MayaCallbacks::addMesh(const wchar_t*, const double* vtx, size_t vtxSize, c
 	newMetadata.makeUnique();
 	MCHECK(stat);
 	adsk::Data::Channel newChannel = newMetadata.channel(PRT_MATERIAL_CHANNEL);
-	const adsk::Data::Structure* fStructure = getMaterialDataStructure(materials, faceRangesSize);
 	adsk::Data::Stream newStream(*fStructure, PRT_MATERIAL_STREAM);
 
 	newChannel.setDataStream(newStream);

--- a/src/serlio/modifiers/MayaCallbacks.cpp
+++ b/src/serlio/modifiers/MayaCallbacks.cpp
@@ -382,9 +382,9 @@ void MayaCallbacks::addMesh(const wchar_t*, const double* vtx, size_t vtxSize, c
 	                                 mayaVertexIndices, newOutputData, &stat);
 	MCHECK(stat);
 
-	MFnMesh fnMesh(oMesh);
-	assignTextureCoordinates(fnMesh, uvs, uvsSizes, uvCounts, uvCountsSizes, uvIndices, uvIndicesSizes, uvSetsCount);
-	assignVertexNormals(fnMesh, mayaFaceCounts, mayaVertexIndices, nrm, nrmSize, normalIndices, normalIndicesSize);
+	MFnMesh mFnMesh(oMesh);
+	assignTextureCoordinates(mFnMesh, uvs, uvsSizes, uvCounts, uvCountsSizes, uvIndices, uvIndicesSizes, uvSetsCount);
+	assignVertexNormals(mFnMesh, mayaFaceCounts, mayaVertexIndices, nrm, nrmSize, normalIndices, normalIndicesSize);
 
 	MFnMesh inputMesh(inMeshObj);
 	MFnMesh outputMesh(outMeshObj);

--- a/src/serlio/modifiers/MayaCallbacks.cpp
+++ b/src/serlio/modifiers/MayaCallbacks.cpp
@@ -193,16 +193,16 @@ void MayaCallbacks::addMesh(const wchar_t*, const double* vtx, size_t vtxSize, c
 	MCHECK(stat);
 
 	MFnMesh mFnMesh1;
-	MObject oMesh = mFnMesh1.create(mayaVertices.length(), mayaFaceCounts.length(), mayaVertices, mayaFaceCounts,
+	MObject newMeshObj = mFnMesh1.create(mayaVertices.length(), mayaFaceCounts.length(), mayaVertices, mayaFaceCounts,
 	                                mayaVertexIndices, newOutputData, &stat);
 	MCHECK(stat);
 
-	MFnMesh mFnMesh(oMesh);
-	assignTextureCoordinates(mFnMesh, uvs, uvsSizes, uvCounts, uvCountsSizes, uvIndices, uvIndicesSizes, uvSetsCount);
-	assignVertexNormals(mFnMesh, mayaFaceCounts, mayaVertexIndices, nrm, nrmSize, normalIndices, normalIndicesSize);
+	MFnMesh newMesh(newMeshObj);
+	assignTextureCoordinates(newMesh, uvs, uvsSizes, uvCounts, uvCountsSizes, uvIndices, uvIndicesSizes, uvSetsCount);
+	assignVertexNormals(newMesh, mayaFaceCounts, mayaVertexIndices, nrm, nrmSize, normalIndices, normalIndicesSize);
 
 	MFnMesh outputMesh(outMeshObj);
-	outputMesh.copyInPlace(oMesh);
+	outputMesh.copyInPlace(newMeshObj);
 
 	// create material metadata
 	constexpr unsigned int maxStringLength = 400;

--- a/src/serlio/modifiers/MayaCallbacks.cpp
+++ b/src/serlio/modifiers/MayaCallbacks.cpp
@@ -164,9 +164,9 @@ void assignVertexNormals(MFnMesh& mFnMesh, MIntArray& mayaFaceCounts, MIntArray&
 	MCHECK(mFnMesh.setFaceVertexNormals(expandedNormals, faceList, mayaVertexIndices));
 }
 
-constexpr unsigned int MATERIAL_MAX_STRING_LENGTH = 400;
-constexpr unsigned int MATERIAL_MAX_FLOAT_ARRAY_LENGTH = 5;
-constexpr unsigned int MATERIAL_MAX_STRING_ARRAY_LENGTH = 2;
+constexpr unsigned int maxStringLength = 400;
+constexpr unsigned int maxFloatArrayLength = 5;
+constexpr unsigned int maxStringArrayLength = 2;
 
 adsk::Data::Structure* getMaterialDataStructure(const prt::AttributeMap** materials, size_t faceRangesSize) {
 	adsk::Data::Structure* fStructure = adsk::Data::Structure::structureByName(PRT_MATERIAL_STRUCTURE.c_str());
@@ -196,11 +196,11 @@ adsk::Data::Structure* getMaterialDataStructure(const prt::AttributeMap** materi
 				case prt::Attributable::PT_INT: type = adsk::Data::Member::kInt32; size = 1; break;
 
 				// workaround: using kString type crashes maya when setting metadata elements. Therefore we use array of kUInt8
-				case prt::Attributable::PT_STRING: type = adsk::Data::Member::kUInt8; size = MATERIAL_MAX_STRING_LENGTH;  break;
-				case prt::Attributable::PT_BOOL_ARRAY: type = adsk::Data::Member::kBoolean; size = MATERIAL_MAX_STRING_LENGTH; break;
-				case prt::Attributable::PT_INT_ARRAY: type = adsk::Data::Member::kInt32; size = MATERIAL_MAX_STRING_LENGTH; break;
-				case prt::Attributable::PT_FLOAT_ARRAY: type = adsk::Data::Member::kDouble; size = MATERIAL_MAX_FLOAT_ARRAY_LENGTH; break;
-				case prt::Attributable::PT_STRING_ARRAY: type = adsk::Data::Member::kUInt8; size = MATERIAL_MAX_STRING_LENGTH; arrayLength = MATERIAL_MAX_STRING_ARRAY_LENGTH; break;
+				case prt::Attributable::PT_STRING: type = adsk::Data::Member::kUInt8; size = maxStringLength;  break;
+				case prt::Attributable::PT_BOOL_ARRAY: type = adsk::Data::Member::kBoolean; size = maxStringLength; break;
+				case prt::Attributable::PT_INT_ARRAY: type = adsk::Data::Member::kInt32; size = maxStringLength; break;
+				case prt::Attributable::PT_FLOAT_ARRAY: type = adsk::Data::Member::kDouble; size = maxFloatArrayLength; break;
+				case prt::Attributable::PT_STRING_ARRAY: type = adsk::Data::Member::kUInt8; size = maxStringLength; arrayLength = maxStringArrayLength; break;
 
 				case prt::Attributable::PT_UNDEFINED: break;
 				case prt::Attributable::PT_BLIND_DATA: break;
@@ -318,29 +318,29 @@ void MayaCallbacks::addMesh(const wchar_t*, const double* vtx, size_t vtxSize, c
 							const wchar_t* str = mat->getString(key);
 							if (wcslen(str) == 0)
 								break;
-							checkStringLength(str, MATERIAL_MAX_STRING_LENGTH);
-							size_t maxStringLengthTmp = MATERIAL_MAX_STRING_LENGTH;
+							checkStringLength(str, maxStringLength);
+							size_t maxStringLengthTmp = maxStringLength;
 							prt::StringUtils::toOSNarrowFromUTF16(str, (char*)handle.asUInt8(), &maxStringLengthTmp);
 							break;
 						}
 						case prt::Attributable::PT_BOOL_ARRAY: {
 							const bool* boolArray;
 							boolArray = mat->getBoolArray(key, &arraySize);
-							for (unsigned int i = 0; i < arraySize && i < MATERIAL_MAX_STRING_LENGTH; i++)
+							for (unsigned int i = 0; i < arraySize && i < maxStringLength; i++)
 								handle.asBoolean()[i] = boolArray[i];
 							break;
 						}
 						case prt::Attributable::PT_INT_ARRAY: {
 							const int* intArray;
 							intArray = mat->getIntArray(key, &arraySize);
-							for (unsigned int i = 0; i < arraySize && i < MATERIAL_MAX_STRING_LENGTH; i++)
+							for (unsigned int i = 0; i < arraySize && i < maxStringLength; i++)
 								handle.asInt32()[i] = intArray[i];
 							break;
 						}
 						case prt::Attributable::PT_FLOAT_ARRAY: {
 							const double* floatArray;
 							floatArray = mat->getFloatArray(key, &arraySize);
-							for (unsigned int i = 0; i < arraySize && i < MATERIAL_MAX_STRING_LENGTH && i < MATERIAL_MAX_FLOAT_ARRAY_LENGTH;
+							for (unsigned int i = 0; i < arraySize && i < maxStringLength && i < maxFloatArrayLength;
 							     i++)
 								handle.asDouble()[i] = floatArray[i];
 							break;
@@ -349,7 +349,7 @@ void MayaCallbacks::addMesh(const wchar_t*, const double* vtx, size_t vtxSize, c
 
 							const wchar_t* const* stringArray = mat->getStringArray(key, &arraySize);
 
-							for (unsigned int i = 0; i < arraySize && i < MATERIAL_MAX_STRING_LENGTH; i++) {
+							for (unsigned int i = 0; i < arraySize && i < maxStringLength; i++) {
 								if (wcslen(stringArray[i]) == 0)
 									continue;
 
@@ -360,8 +360,8 @@ void MayaCallbacks::addMesh(const wchar_t*, const double* vtx, size_t vtxSize, c
 										continue;
 								}
 
-								checkStringLength(stringArray[i], MATERIAL_MAX_STRING_LENGTH);
-								size_t maxStringLengthTmp = MATERIAL_MAX_STRING_LENGTH;
+								checkStringLength(stringArray[i], maxStringLength);
+								size_t maxStringLengthTmp = maxStringLength;
 								prt::StringUtils::toOSNarrowFromUTF16(stringArray[i], (char*)handle.asUInt8(),
 								                                      &maxStringLengthTmp);
 							}

--- a/src/serlio/modifiers/MayaCallbacks.cpp
+++ b/src/serlio/modifiers/MayaCallbacks.cpp
@@ -164,6 +164,10 @@ void assignVertexNormals(MFnMesh& mFnMesh, MIntArray& mayaFaceCounts, MIntArray&
 	MCHECK(mFnMesh.setFaceVertexNormals(expandedNormals, faceList, mayaVertexIndices));
 }
 
+constexpr unsigned int MATERIAL_MAX_STRING_LENGTH = 400;
+constexpr unsigned int MATERIAL_MAX_FLOAT_ARRAY_LENGTH = 5;
+constexpr unsigned int MATERIAL_MAX_STRING_ARRAY_LENGTH = 2;
+
 } // namespace
 
 void MayaCallbacks::addMesh(const wchar_t*, const double* vtx, size_t vtxSize, const double* nrm, size_t nrmSize,
@@ -205,10 +209,6 @@ void MayaCallbacks::addMesh(const wchar_t*, const double* vtx, size_t vtxSize, c
 	outputMesh.copyInPlace(newMeshObj);
 
 	// create material metadata
-	constexpr unsigned int maxStringLength = 400;
-	constexpr unsigned int maxFloatArrayLength = 5;
-	constexpr unsigned int maxStringArrayLength = 2;
-
 	adsk::Data::Structure* fStructure; // Structure to use for creation
 	fStructure = adsk::Data::Structure::structureByName(PRT_MATERIAL_STRUCTURE.c_str());
 	if ((fStructure == nullptr) && (materials != nullptr) && (faceRangesSize > 1)) {
@@ -237,11 +237,11 @@ void MayaCallbacks::addMesh(const wchar_t*, const double* vtx, size_t vtxSize, c
 				case prt::Attributable::PT_INT: type = adsk::Data::Member::kInt32; size = 1; break;
 
 				//workaround: using kString type crashes maya when setting metadata elememts. Therefore we use array of kUInt8
-				case prt::Attributable::PT_STRING: type = adsk::Data::Member::kUInt8; size = maxStringLength;  break;
-				case prt::Attributable::PT_BOOL_ARRAY: type = adsk::Data::Member::kBoolean; size = maxStringLength; break;
-				case prt::Attributable::PT_INT_ARRAY: type = adsk::Data::Member::kInt32; size = maxStringLength; break;
-				case prt::Attributable::PT_FLOAT_ARRAY: type = adsk::Data::Member::kDouble; size = maxFloatArrayLength; break;
-				case prt::Attributable::PT_STRING_ARRAY: type = adsk::Data::Member::kUInt8; size = maxStringLength; arrayLength = maxStringArrayLength; break;
+				case prt::Attributable::PT_STRING: type = adsk::Data::Member::kUInt8; size = MATERIAL_MAX_STRING_LENGTH;  break;
+				case prt::Attributable::PT_BOOL_ARRAY: type = adsk::Data::Member::kBoolean; size = MATERIAL_MAX_STRING_LENGTH; break;
+				case prt::Attributable::PT_INT_ARRAY: type = adsk::Data::Member::kInt32; size = MATERIAL_MAX_STRING_LENGTH; break;
+				case prt::Attributable::PT_FLOAT_ARRAY: type = adsk::Data::Member::kDouble; size = MATERIAL_MAX_FLOAT_ARRAY_LENGTH; break;
+				case prt::Attributable::PT_STRING_ARRAY: type = adsk::Data::Member::kUInt8; size = MATERIAL_MAX_STRING_LENGTH; arrayLength = MATERIAL_MAX_STRING_ARRAY_LENGTH; break;
 
 				case prt::Attributable::PT_UNDEFINED: break;
 				case prt::Attributable::PT_BLIND_DATA: break;
@@ -315,29 +315,29 @@ void MayaCallbacks::addMesh(const wchar_t*, const double* vtx, size_t vtxSize, c
 							const wchar_t* str = mat->getString(key);
 							if (wcslen(str) == 0)
 								break;
-							checkStringLength(str, maxStringLength);
-							size_t maxStringLengthTmp = maxStringLength;
+							checkStringLength(str, MATERIAL_MAX_STRING_LENGTH);
+							size_t maxStringLengthTmp = MATERIAL_MAX_STRING_LENGTH;
 							prt::StringUtils::toOSNarrowFromUTF16(str, (char*)handle.asUInt8(), &maxStringLengthTmp);
 							break;
 						}
 						case prt::Attributable::PT_BOOL_ARRAY: {
 							const bool* boolArray;
 							boolArray = mat->getBoolArray(key, &arraySize);
-							for (unsigned int i = 0; i < arraySize && i < maxStringLength; i++)
+							for (unsigned int i = 0; i < arraySize && i < MATERIAL_MAX_STRING_LENGTH; i++)
 								handle.asBoolean()[i] = boolArray[i];
 							break;
 						}
 						case prt::Attributable::PT_INT_ARRAY: {
 							const int* intArray;
 							intArray = mat->getIntArray(key, &arraySize);
-							for (unsigned int i = 0; i < arraySize && i < maxStringLength; i++)
+							for (unsigned int i = 0; i < arraySize && i < MATERIAL_MAX_STRING_LENGTH; i++)
 								handle.asInt32()[i] = intArray[i];
 							break;
 						}
 						case prt::Attributable::PT_FLOAT_ARRAY: {
 							const double* floatArray;
 							floatArray = mat->getFloatArray(key, &arraySize);
-							for (unsigned int i = 0; i < arraySize && i < maxStringLength && i < maxFloatArrayLength;
+							for (unsigned int i = 0; i < arraySize && i < MATERIAL_MAX_STRING_LENGTH && i < MATERIAL_MAX_FLOAT_ARRAY_LENGTH;
 							     i++)
 								handle.asDouble()[i] = floatArray[i];
 							break;
@@ -346,7 +346,7 @@ void MayaCallbacks::addMesh(const wchar_t*, const double* vtx, size_t vtxSize, c
 
 							const wchar_t* const* stringArray = mat->getStringArray(key, &arraySize);
 
-							for (unsigned int i = 0; i < arraySize && i < maxStringLength; i++) {
+							for (unsigned int i = 0; i < arraySize && i < MATERIAL_MAX_STRING_LENGTH; i++) {
 								if (wcslen(stringArray[i]) == 0)
 									continue;
 
@@ -357,8 +357,8 @@ void MayaCallbacks::addMesh(const wchar_t*, const double* vtx, size_t vtxSize, c
 										continue;
 								}
 
-								checkStringLength(stringArray[i], maxStringLength);
-								size_t maxStringLengthTmp = maxStringLength;
+								checkStringLength(stringArray[i], MATERIAL_MAX_STRING_LENGTH);
+								size_t maxStringLengthTmp = MATERIAL_MAX_STRING_LENGTH;
 								prt::StringUtils::toOSNarrowFromUTF16(stringArray[i], (char*)handle.asUInt8(),
 								                                      &maxStringLengthTmp);
 							}


### PR DESCRIPTION
Investigated wrong wall textures for the "Medieval Example" of CityEngine:
* Regression introduced by recent cleanup (fixed here by reverting some of the cleanups)
* Known bug in enum handling (#23)
* Unexpected behavior of dependent rule attributes due to limited functionality (#50)