### PR TITLE
Switch rules instead of adding a second prt node

### DIFF
--- a/src/serlio/scripts/serlioCreateUI.mel
+++ b/src/serlio/scripts/serlioCreateUI.mel
@@ -59,7 +59,7 @@ global proc createPrtNode() {
 			string $nodeHistory[] = `listHistory $node`;
 
 			for($dpNode in $nodeHistory){
-				$dpNodeType = `nodeType $dpNode`;
+				string $dpNodeType = `nodeType $dpNode`;
 				if($dpNodeType == "serlio"){
 					setAttr -type "string" ($dpNode + ".Rule_Package") $rulePackage[0];  
 					evalDeferred "refreshEditorTemplates()";

--- a/src/serlio/scripts/serlioCreateUI.mel
+++ b/src/serlio/scripts/serlioCreateUI.mel
@@ -51,10 +51,27 @@ global proc createPrtNode() {
 	string $rulePackage[] = `fileDialog2 -fm 1 -cap "Select Rule Package" -ff $filters`;
 	
 	
+	int $alreadyHasExistingPrtNode = false;
+
 	if(size($rulePackage)) {
 		for($node in $initialShapes) {
 			select -r $node;
-			serlioAssign $rulePackage;
+			string $nodeHistory[] = `listHistory $node`;
+
+			for($dpNode in $nodeHistory){
+				$dpNodeType = `nodeType $dpNode`;
+				if($dpNodeType == "serlio"){
+					setAttr -type "string" ($dpNode + ".Rule_Package") $rulePackage[0];  
+					evalDeferred "refreshEditorTemplates()";
+					$alreadyHasExistingPrtNode = true;
+				}
+			}
+
+			if (!alreadyHasExistingPrtNode){
+				select -r $node;
+				serlioAssign $rulePackage;
+			}
+			$alreadyHasExistingPrtNode = false;
 		}
 	}
 	select -r $select;

--- a/src/serlio/scripts/serlioCreateUI.mel
+++ b/src/serlio/scripts/serlioCreateUI.mel
@@ -80,7 +80,7 @@ global proc removePrtNode() {
 	string $initialShapes[] = collectInitialShapes($select);
 	
 	if(size($initialShapes) == 0) {
-		confirmDialog -title "Missing selection" -message "Please select at least one shape to remove the associated rule package." -button "OK"
+		confirmDialog -title "Missing selection" -message "Please select at least one shape to remove the associated rule package." -button "OK";
 		return;
 	}
 

--- a/src/serlio/scripts/serlioCreateUI.mel
+++ b/src/serlio/scripts/serlioCreateUI.mel
@@ -67,7 +67,7 @@ global proc createPrtNode() {
 				}
 			}
 
-			if (!alreadyHasExistingPrtNode){
+			if (!$alreadyHasExistingPrtNode){
 				select -r $node;
 				serlioAssign $rulePackage;
 			}


### PR DESCRIPTION
- Check for an existing serlio node and switch the rule package instead of using a complex building as the new initial shape for another serlio node. (only works with active construction history)
- Now behaves like switching an rpk on the serlionode itself