### PR TITLE
Check for nullptr before accessing its value

### DIFF
--- a/src/codec/encoder/MayaEncoder.cpp
+++ b/src/codec/encoder/MayaEncoder.cpp
@@ -552,6 +552,9 @@ void MayaEncoder::encode(prtx::GenerateContext& context, size_t initialShapeInde
 
 void MayaEncoder::convertGeometry(const prtx::InitialShape& initialShape,
                                   const prtx::EncodePreparator::InstanceVector& instances, IMayaCallbacks* cb) {
+	if (instances.size() == 0)
+		return;
+	
 	const bool emitMaterials = getOptions()->getBool(EO_EMIT_MATERIALS);
 	const bool emitReports = getOptions()->getBool(EO_EMIT_REPORTS);
 
@@ -617,6 +620,9 @@ void MayaEncoder::convertGeometry(const prtx::InitialShape& initialShape,
 		++repIt;
 	}
 	faceRanges.push_back(faceCount); // close last range
+
+	if (faceRanges.size() <= 1)
+		return;
 
 	assert(matAttrMaps.v.empty() || matAttrMaps.v.size() == faceRanges.size() - 1);
 	assert(reportAttrMaps.v.empty() || reportAttrMaps.v.size() == faceRanges.size() - 1);

--- a/src/codec/encoder/MayaEncoder.cpp
+++ b/src/codec/encoder/MayaEncoder.cpp
@@ -552,7 +552,7 @@ void MayaEncoder::encode(prtx::GenerateContext& context, size_t initialShapeInde
 
 void MayaEncoder::convertGeometry(const prtx::InitialShape& initialShape,
                                   const prtx::EncodePreparator::InstanceVector& instances, IMayaCallbacks* cb) {
-	if (instances.size() == 0)
+	if (instances.empty())
 		return;
 	
 	const bool emitMaterials = getOptions()->getBool(EO_EMIT_MATERIALS);

--- a/src/codec/encoder/MayaEncoder.cpp
+++ b/src/codec/encoder/MayaEncoder.cpp
@@ -88,10 +88,7 @@ struct SerializedGeometry {
 	}
 
 	bool isEmpty() const {
-		if (coords.empty() || counts.empty() || vertexIndices.empty()) {
-			return true;
-		}
-		return false;
+		return coords.empty() || counts.empty() || vertexIndices.empty();
 	}
 };
 
@@ -584,9 +581,8 @@ void MayaEncoder::convertGeometry(const prtx::InitialShape& initialShape,
 
 	const SerializedGeometry sg = detail::serializeGeometry(geometries, materials);
 
-	if (sg.isEmpty()) {
+	if (sg.isEmpty())
 		return;
-	}
 
 	if (DBG) {
 		log_debug("resolvemap: %s") % prtx::PRTUtils::objectToXML(initialShape.getResolveMap());

--- a/src/codec/encoder/MayaEncoder.cpp
+++ b/src/codec/encoder/MayaEncoder.cpp
@@ -86,6 +86,13 @@ struct SerializedGeometry {
 		vertexIndices.reserve(numIndices);
 		normalIndices.reserve(numIndices);
 	}
+
+	bool isEmpty() const {
+		if (coords.empty() || counts.empty() || vertexIndices.empty()) {
+			return true;
+		}
+		return false;
+	}
 };
 
 const prtx::EncodePreparator::PreparationFlags PREP_FLAGS =

--- a/src/codec/encoder/MayaEncoder.cpp
+++ b/src/codec/encoder/MayaEncoder.cpp
@@ -584,6 +584,10 @@ void MayaEncoder::convertGeometry(const prtx::InitialShape& initialShape,
 
 	const SerializedGeometry sg = detail::serializeGeometry(geometries, materials);
 
+	if (sg.isEmpty()) {
+		return;
+	}
+
 	if (DBG) {
 		log_debug("resolvemap: %s") % prtx::PRTUtils::objectToXML(initialShape.getResolveMap());
 		log_debug("encoder #materials = %s") % materials.size();
@@ -627,9 +631,6 @@ void MayaEncoder::convertGeometry(const prtx::InitialShape& initialShape,
 		++repIt;
 	}
 	faceRanges.push_back(faceCount); // close last range
-
-	if (faceRanges.size() <= 1)
-		return;
 
 	assert(matAttrMaps.v.empty() || matAttrMaps.v.size() == faceRanges.size() - 1);
 	assert(reportAttrMaps.v.empty() || reportAttrMaps.v.size() == faceRanges.size() - 1);

--- a/src/serlio/modifiers/MayaCallbacks.cpp
+++ b/src/serlio/modifiers/MayaCallbacks.cpp
@@ -353,10 +353,9 @@ void fillMetadata(adsk::Data::Structure* fStructure, const uint32_t* faceRanges,
 
 void updateMayaMesh(double const* const* uvs, size_t const* uvsSizes, uint32_t const* const* uvCounts,
                     size_t const* uvCountsSizes, uint32_t const* const* uvIndices, size_t const* uvIndicesSizes,
-                    size_t uvSetsCount, const double* nrm, size_t nrmSize, const uint32_t* vertexIndices,
-                    size_t vertexIndicesSize, const uint32_t* normalIndices, size_t normalIndicesSize,
-                    MFloatPointArray& mayaVertices, MIntArray& mayaFaceCounts, MIntArray& mayaVertexIndices,
-                    MObject& outMeshObj, adsk::Data::Associations& newMetadata) {
+                    size_t uvSetsCount, const double* nrm, size_t nrmSize, const uint32_t* normalIndices,
+                    size_t normalIndicesSize, MFloatPointArray& mayaVertices, MIntArray& mayaFaceCounts,
+                    MIntArray& mayaVertexIndices, MObject& outMeshObj, adsk::Data::Associations& newMetadata) {
 	MStatus stat;
 
 	MFnMeshData dataCreator;
@@ -428,8 +427,8 @@ void MayaCallbacks::addMesh(const wchar_t*, const double* vtx, size_t vtxSize, c
 	}
 
 	updateMayaMesh(uvs, uvsSizes, uvCounts, uvCountsSizes, uvIndices, uvIndicesSizes, uvSetsCount, nrm, nrmSize,
-	               vertexIndices, vertexIndicesSize, normalIndices, normalIndicesSize, mayaVertices, mayaFaceCounts,
-	               mayaVertexIndices, outMeshObj, newMetadata);
+	               normalIndices, normalIndicesSize, mayaVertices, mayaFaceCounts, mayaVertexIndices, outMeshObj,
+	               newMetadata);
 }
 
 prt::Status MayaCallbacks::attrBool(size_t /*isIndex*/, int32_t /*shapeID*/, const wchar_t* key, bool value) {

--- a/src/serlio/modifiers/MayaCallbacks.cpp
+++ b/src/serlio/modifiers/MayaCallbacks.cpp
@@ -31,11 +31,11 @@
 #include "maya/MFloatArray.h"
 #include "maya/MFloatPointArray.h"
 #include "maya/MFloatVectorArray.h"
+#include "maya/MFnDependencyNode.h"
 #include "maya/MFnMesh.h"
 #include "maya/MFnMeshData.h"
 #include "maya/adskDataAssociations.h"
 #include "maya/adskDataStream.h"
-#include "maya/MFnDependencyNode.h"
 
 #include <cassert>
 #include <sstream>
@@ -199,7 +199,7 @@ void MayaCallbacks::addMesh(const wchar_t*, const double* vtx, size_t vtxSize, c
 
 	MFnMesh mFnMesh1;
 	MObject newMeshObj = mFnMesh1.create(mayaVertices.length(), mayaFaceCounts.length(), mayaVertices, mayaFaceCounts,
-	                                mayaVertexIndices, newOutputData, &stat);
+	                                     mayaVertexIndices, newOutputData, &stat);
 	MCHECK(stat);
 
 	MFnMesh newMesh(newMeshObj);
@@ -395,13 +395,11 @@ void MayaCallbacks::addMesh(const wchar_t*, const double* vtx, size_t vtxSize, c
 				}
 			}
 		}
-
 	}
-
 
 	outputMesh.setMetadata(newMetadata);
 
-	//manually set the plug value, since copyInPlace is broken for meshes without construction history
+	// manually set the plug value, since copyInPlace is broken for meshes without construction history
 	if (outMeshObj.apiType() == MFn::Type::kMesh) {
 		mFnMesh1.setMetadata(newMetadata);
 

--- a/src/serlio/modifiers/MayaCallbacks.cpp
+++ b/src/serlio/modifiers/MayaCallbacks.cpp
@@ -138,7 +138,7 @@ void assignTextureCoordinates(MFnMesh& fnMesh, double const* const* uvs, size_t 
 	}
 }
 
-void assignVertexNormals(MFnMesh& mFnMesh, MIntArray& mayaFaceCounts, MIntArray& mayaVertexIndices, const double* nrm,
+void assignVertexNormals(MFnMesh& mFnMesh, const MIntArray& mayaFaceCounts, MIntArray& mayaVertexIndices, const double* nrm,
                          size_t nrmSize, const uint32_t* normalIndices, MAYBE_UNUSED size_t normalIndicesSize) {
 	if (nrmSize == 0)
 		return;
@@ -354,8 +354,8 @@ void fillMetadata(adsk::Data::Structure* fStructure, const uint32_t* faceRanges,
 void updateMayaMesh(double const* const* uvs, size_t const* uvsSizes, uint32_t const* const* uvCounts,
                     size_t const* uvCountsSizes, uint32_t const* const* uvIndices, size_t const* uvIndicesSizes,
                     size_t uvSetsCount, const double* nrm, size_t nrmSize, const uint32_t* normalIndices,
-                    size_t normalIndicesSize, MFloatPointArray& mayaVertices, MIntArray& mayaFaceCounts,
-                    MIntArray& mayaVertexIndices, MObject& outMeshObj, adsk::Data::Associations& newMetadata) {
+                    size_t normalIndicesSize, const MFloatPointArray& mayaVertices, const MIntArray& mayaFaceCounts,
+                    MIntArray& mayaVertexIndices, const MObject& outMeshObj, const adsk::Data::Associations& newMetadata) {
 	MStatus stat;
 
 	MFnMeshData dataCreator;


### PR DESCRIPTION
Fixed bug that caused maya to crash.
Now checking for nullptr before accessing fStructure/ creating a new stream.