### PR TITLE
Flush cache on rpk reload

### DIFF
--- a/src/serlio/modifiers/PRTModifierAction.cpp
+++ b/src/serlio/modifiers/PRTModifierAction.cpp
@@ -281,6 +281,7 @@ MStatus PRTModifierAction::updateRuleFiles(const MObject& node, const MString& r
 	mRuleFile.clear();
 	mStartRule.clear();
 	mRuleAttributes.clear();
+	PRTContext::get().theCache.get()->flushAll();
 
 	ResolveMapSPtr resolveMap = getResolveMap();
 	if (!resolveMap) {


### PR DESCRIPTION
- Fixed reload on files when startrule changes
- Fixed a relating bug when cgb is changed, but keeps the same naming (i.e. rulefile is updated and exported via CE)