### PR TITLE
Cknieling/fix redlands bugs

### DIFF
--- a/src/serlio/modifiers/PRTModifierAction.cpp
+++ b/src/serlio/modifiers/PRTModifierAction.cpp
@@ -364,7 +364,7 @@ MStatus PRTModifierAction::updateUserSetAttributes(const MObject& node) {
 				break;
 			}
 			case PrtAttributeType::COLOR: {
-				const wchar_t* defColStr = defaultAttributeValues->getString(fqAttrName.c_str());
+				const prtu::Color defCol = prtu::parseColor(defaultAttributeValues->getString(fqAttrName.c_str()));
 
 				MObject rgb;
 				MCHECK(plug.getValue(rgb));
@@ -372,9 +372,8 @@ MStatus PRTModifierAction::updateUserSetAttributes(const MObject& node) {
 
 				prtu::Color col;
 				MCHECK(fRGB.getData3Float(col[0], col[1], col[2]));
-				const std::wstring colStr = prtu::getColorString(col);
 
-				isDefaultValue = std::wcscmp(colStr.c_str(), defColStr) == 0;
+				isDefaultValue = defCol == col;
 				break;
 			}
 			case PrtAttributeType::STRING: {

--- a/src/serlio/modifiers/PRTModifierAction.cpp
+++ b/src/serlio/modifiers/PRTModifierAction.cpp
@@ -404,8 +404,8 @@ MStatus PRTModifierAction::updateUserSetAttributes(const MObject& node) {
 		if (getAndResetForceDefault(fnNode, fnAttribute)) {
 			setIsUserSet(fnNode, fnAttribute, false);
 		}
-		else {
-			setIsUserSet(fnNode, fnAttribute, !isDefaultValue);
+		else if (!isDefaultValue){
+			setIsUserSet(fnNode, fnAttribute, true);
 		}
 	};
 

--- a/src/serlio/modifiers/PRTModifierAction.cpp
+++ b/src/serlio/modifiers/PRTModifierAction.cpp
@@ -352,7 +352,7 @@ MStatus PRTModifierAction::updateUserSetAttributes(const MObject& node) {
 				bool boolVal;
 				MCHECK(plug.getValue(boolVal));
 
-				isDefaultValue = defBoolVal == boolVal;
+				isDefaultValue = (defBoolVal == boolVal);
 				break;
 			}
 			case PrtAttributeType::FLOAT: {
@@ -360,7 +360,7 @@ MStatus PRTModifierAction::updateUserSetAttributes(const MObject& node) {
 				double doubleVal;
 				MCHECK(plug.getValue(doubleVal));
 
-				isDefaultValue = defDoubleVal == doubleVal;
+				isDefaultValue = (defDoubleVal == doubleVal);
 				break;
 			}
 			case PrtAttributeType::COLOR: {
@@ -373,7 +373,7 @@ MStatus PRTModifierAction::updateUserSetAttributes(const MObject& node) {
 				prtu::Color col;
 				MCHECK(fRGB.getData3Float(col[0], col[1], col[2]));
 
-				isDefaultValue = defCol == col;
+				isDefaultValue = (defCol == col);
 				break;
 			}
 			case PrtAttributeType::STRING: {
@@ -382,7 +382,7 @@ MStatus PRTModifierAction::updateUserSetAttributes(const MObject& node) {
 				MString stringVal;
 				MCHECK(plug.getValue(stringVal));
 
-				isDefaultValue = std::wcscmp(stringVal.asWChar(), defStringVal) == 0;
+				isDefaultValue = (std::wcscmp(stringVal.asWChar(), defStringVal) == 0);
 				break;
 			}
 			case PrtAttributeType::ENUM: {
@@ -393,7 +393,7 @@ MStatus PRTModifierAction::updateUserSetAttributes(const MObject& node) {
 				MCHECK(eAttr.getDefault(defEnumVal));
 				MCHECK(plug.getValue(enumVal));
 
-				isDefaultValue = defEnumVal == enumVal;
+				isDefaultValue = (defEnumVal == enumVal);
 				break;
 			}
 
@@ -428,7 +428,7 @@ MStatus PRTModifierAction::updateUI(const MObject& node) {
 				bool boolVal;
 				MCHECK(plug.getValue(boolVal));
 
-				const bool isDefaultValue = defBoolVal == boolVal;
+				const bool isDefaultValue = (defBoolVal == boolVal);
 
 				if (getIsUserSet(fnNode, fnAttribute)) {
 					plug.setBool(boolVal);
@@ -445,7 +445,7 @@ MStatus PRTModifierAction::updateUI(const MObject& node) {
 				double doubleVal;
 				MCHECK(plug.getValue(doubleVal));
 
-				const bool isDefaultValue = defDoubleVal == doubleVal;
+				const bool isDefaultValue = (defDoubleVal == doubleVal);
 
 				if (getIsUserSet(fnNode, fnAttribute)) {
 					plug.setDouble(doubleVal);
@@ -473,7 +473,7 @@ MStatus PRTModifierAction::updateUI(const MObject& node) {
 				MObject defaultColorObj = fdefaultColor.create(MFnNumericData::Type::k3Float);
 				fdefaultColor.setData3Float(defaultColor[0], defaultColor[1], defaultColor[2]);
 
-				const bool isDefaultValue = std::wcscmp(colStr.c_str(), defColStr) == 0;
+				const bool isDefaultValue = (std::wcscmp(colStr.c_str(), defColStr) == 0);
 
 				if (getIsUserSet(fnNode, fnAttribute)) {
 					plug.setMObject(rgb);
@@ -491,7 +491,7 @@ MStatus PRTModifierAction::updateUI(const MObject& node) {
 				MString stringVal;
 				MCHECK(plug.getValue(stringVal));
 
-				const bool isDefaultValue = std::wcscmp(stringVal.asWChar(), defStringVal) == 0;
+				const bool isDefaultValue = (std::wcscmp(stringVal.asWChar(), defStringVal) == 0);
 
 				if (getIsUserSet(fnNode, fnAttribute)) {
 					plug.setString(stringVal);
@@ -511,7 +511,7 @@ MStatus PRTModifierAction::updateUI(const MObject& node) {
 				MCHECK(eAttr.getDefault(defEnumVal));
 				MCHECK(plug.getValue(enumVal));
 
-				const bool isDefaultValue = defEnumVal == enumVal;
+				const bool isDefaultValue = (defEnumVal == enumVal);
 				if (getIsUserSet(fnNode, fnAttribute)) {
 					plug.setShort(enumVal);
 				}

--- a/src/serlio/modifiers/PRTModifierAction.cpp
+++ b/src/serlio/modifiers/PRTModifierAction.cpp
@@ -980,9 +980,12 @@ MStatus PRTModifierAction::addFloatParameter(MFnDependencyNode& node, MObject& a
 
 MStatus PRTModifierAction::addEnumParameter(const prt::Annotation* annot, MFnDependencyNode& node, MObject& attr,
                                             const RuleAttribute& ruleAttr, bool defaultValue, PRTModifierEnum& e) {
+	PRTModifierEnum tmpEnum;
+	tmpEnum.fill(annot);
+
 	short idx = 0;
-	for (int i = static_cast<int>(e.mBVals.length()); --i >= 0;) {
-		if ((e.mBVals[i] != 0) == defaultValue) {
+	for (int i = static_cast<int>(tmpEnum.mBVals.length()); --i >= 0;) {
+		if ((tmpEnum.mBVals[i] != 0) == defaultValue) {
 			idx = static_cast<short>(i);
 			break;
 		}
@@ -993,9 +996,12 @@ MStatus PRTModifierAction::addEnumParameter(const prt::Annotation* annot, MFnDep
 
 MStatus PRTModifierAction::addEnumParameter(const prt::Annotation* annot, MFnDependencyNode& node, MObject& attr,
                                             const RuleAttribute& ruleAttr, double defaultValue, PRTModifierEnum& e) {
+	PRTModifierEnum tmpEnum;
+	tmpEnum.fill(annot);
+
 	short idx = 0;
-	for (int i = static_cast<int>(e.mFVals.length()); --i >= 0;) {
-		if (e.mFVals[i] == defaultValue) {
+	for (int i = static_cast<int>(tmpEnum.mFVals.length()); --i >= 0;) {
+		if (tmpEnum.mFVals[i] == defaultValue) {
 			idx = static_cast<short>(i);
 			break;
 		}
@@ -1007,9 +1013,12 @@ MStatus PRTModifierAction::addEnumParameter(const prt::Annotation* annot, MFnDep
 MStatus PRTModifierAction::addEnumParameter(const prt::Annotation* annot, MFnDependencyNode& node, MObject& attr,
                                             const RuleAttribute& ruleAttr, const MString& defaultValue,
                                             PRTModifierEnum& e) {
+	PRTModifierEnum tmpEnum;
+	tmpEnum.fill(annot);
+
 	short idx = 0;
-	for (int i = static_cast<int>(e.mSVals.length()); --i >= 0;) {
-		if (e.mSVals[i] == defaultValue) {
+	for (int i = static_cast<int>(tmpEnum.mSVals.length()); --i >= 0;) {
+		if (tmpEnum.mSVals[i] == defaultValue) {
 			idx = static_cast<short>(i);
 			break;
 		}


### PR DESCRIPTION
fixed issues with redlands construction building:
- enums with default value =/= 0 are now properly working
- color attributes with default value representing a non-valid color can now be used without automatically being force set to RGB(0,0,0)