### PR TITLE
Only update user_set highlights when user_set changes

### DIFF
--- a/src/serlio/modifiers/PRTModifierAction.cpp
+++ b/src/serlio/modifiers/PRTModifierAction.cpp
@@ -431,13 +431,8 @@ MStatus PRTModifierAction::updateUI(const MObject& node) {
 
 				const bool isDefaultValue = defBoolVal == boolVal;
 
-				if (getIsUserSet(fnNode, fnAttribute)) {
-					plug.setBool(boolVal);
-				}
-				else {
-					if (!isDefaultValue) {
-						plug.setBool(defBoolVal);
-					}
+				if (!getIsUserSet(fnNode, fnAttribute) && !isDefaultValue) {
+				    plug.setBool(defBoolVal);
 				}
 				break;
 			}
@@ -448,13 +443,8 @@ MStatus PRTModifierAction::updateUI(const MObject& node) {
 
 				const bool isDefaultValue = defDoubleVal == doubleVal;
 
-				if (getIsUserSet(fnNode, fnAttribute)) {
-					plug.setDouble(doubleVal);
-				}
-				else {
-					if (!isDefaultValue) {
-						plug.setDouble(defDoubleVal);
-					}
+				if (!getIsUserSet(fnNode, fnAttribute) && !isDefaultValue) {
+					plug.setDouble(defDoubleVal);
 				}
 				break;
 			}
@@ -476,13 +466,8 @@ MStatus PRTModifierAction::updateUI(const MObject& node) {
 
 				const bool isDefaultValue = std::wcscmp(colStr.c_str(), defColStr) == 0;
 
-				if (getIsUserSet(fnNode, fnAttribute)) {
-					plug.setMObject(rgb);
-				}
-				else {
-					if (!isDefaultValue) {
-						plug.setMObject(defaultColorObj);
-					}
+				if (!getIsUserSet(fnNode, fnAttribute) && !isDefaultValue) {
+				    plug.setMObject(defaultColorObj);
 				}
 				break;
 			}
@@ -494,13 +479,8 @@ MStatus PRTModifierAction::updateUI(const MObject& node) {
 
 				const bool isDefaultValue = std::wcscmp(stringVal.asWChar(), defStringVal) == 0;
 
-				if (getIsUserSet(fnNode, fnAttribute)) {
-					plug.setString(stringVal);
-				}
-				else {
-					if (!isDefaultValue) {
-						plug.setString(defStringVal);
-					}
+				if (!getIsUserSet(fnNode, fnAttribute) && !isDefaultValue) {
+				    plug.setString(defStringVal);
 				}
 				break;
 			}
@@ -513,13 +493,9 @@ MStatus PRTModifierAction::updateUI(const MObject& node) {
 				MCHECK(plug.getValue(enumVal));
 
 				const bool isDefaultValue = defEnumVal == enumVal;
-				if (getIsUserSet(fnNode, fnAttribute)) {
-					plug.setShort(enumVal);
-				}
-				else {
-					if (!isDefaultValue) {
-						plug.setShort(defEnumVal);
-					}
+
+				if (!getIsUserSet(fnNode, fnAttribute) && !isDefaultValue) {
+					plug.setShort(defEnumVal);
 				}
 				break;
 			}

--- a/src/serlio/scripts/AEserlioTemplate.mel
+++ b/src/serlio/scripts/AEserlioTemplate.mel
@@ -142,10 +142,8 @@ global proc prtUpdateEditHighlights(string $attr){
 	prtSetBackgroundColor(false, 0.4, $control);
 }
 
-global proc prtSetAttrUserSetAndUpdateUI(string $attr){
+global proc prtForceDefault(string $attr){
 	setAttr ($attr + "_force_default") true;
-	setAttr ($attr + "_user_set") false;
-	prtUpdateEditHighlights($attr);
 }
 
 global proc prtAttributeControl(string $attr, string $varname){
@@ -173,7 +171,7 @@ global proc prtAttributeControl(string $attr, string $varname){
 	if ($isFileAttribute){
 		symbolButton -image "navButtonBrowse.xpm" -c ("prtShowFileDialog(\"" + $attr + "\",\"All Files (*.*)\" )") ($control + "_browse");
 	}
-	symbolButton -image "undo_s.png" -visible false -annotation "reset rule attribute to default value" -c ("prtSetAttrUserSetAndUpdateUI (\"" +  $attr +"\")") ($control + "_force_default_reset");
+	symbolButton -image "undo_s.png" -visible false -annotation "reset rule attribute to default value" -c ("prtForceDefault (\"" +  $attr +"\")") ($control + "_force_default_reset");
 
 	if(prtIsStringAttr($attr)){
 		connectControl -index 2 $control $attr;
@@ -181,7 +179,7 @@ global proc prtAttributeControl(string $attr, string $varname){
 		connectControl $control $attr;
 	}
 	string $changeCommand = "prtUpdateEditHighlights " + $attr;
-	scriptJob -rp -p $control -ac $attr $changeCommand;
+	scriptJob -rp -p $control -ac  ($attr + "_user_set") $changeCommand;
 
 	setParent ..;
 	setUITemplate -ppt; 
@@ -202,9 +200,9 @@ global proc prtAttributeControlReplace(string $attr, string $varname){
 			attrControlGrp -edit -attribute $attr $control;
 			connectControl $control $attr;
 		}
-		symbolButton -edit -c ("prtSetAttrUserSetAndUpdateUI (\"" +  $attr +"\")") ($control + "_force_default_reset");
+		symbolButton -edit -c ("prtForceDefault (\"" +  $attr +"\")") ($control + "_force_default_reset");
 		string $changeCommand = "prtUpdateEditHighlights " + $attr;
-		scriptJob -rp -p $control -ac $attr $changeCommand;
+		scriptJob -rp -p $control -ac ($attr + "_user_set") $changeCommand;
 	}
 	prtUpdateEditHighlights($attr);
 }


### PR DESCRIPTION
- Removed an old hack used to force UI updates
- Only updating the highlight for user set attributes, if the hidden user_set attribute changes value