### PR TITLE
Cknieling/support dependent attributes

### DIFF
--- a/src/serlio/modifiers/PRTModifierAction.cpp
+++ b/src/serlio/modifiers/PRTModifierAction.cpp
@@ -273,7 +273,7 @@ short getDefaultEnumValue(const AttributeMapUPtr& defaultAttributeValues, const 
 			const auto defBoolVal = defaultAttributeValues->getBool(fqAttrName.c_str());
 
 			for (short currIdx = minVal; currIdx <= maxVal; currIdx++) {
-				const int currBool = eAttr.fieldName(currIdx).asInt() != 0;
+				const bool currBool = (eAttr.fieldName(currIdx).asInt() != 0);
 				if (currBool == defBoolVal)
 					return currIdx;
 			}

--- a/src/serlio/modifiers/PRTModifierAction.cpp
+++ b/src/serlio/modifiers/PRTModifierAction.cpp
@@ -389,6 +389,12 @@ MStatus PRTModifierAction::updateUserSetAttributes(const MObject& node) {
 	                                           const RuleAttribute& ruleAttribute, const PrtAttributeType attrType) {
 		const AttributeMapUPtr defaultAttributeValues = getDefaultAttributeValues(
 		        mRuleFile, mStartRule, *getResolveMap(), *PRTContext::get().theCache, *inPrtMesh, mRandomSeed, mGenerateAttrs);
+
+		if (getAndResetForceDefault(fnNode, fnAttribute)) {
+			setIsUserSet(fnNode, fnAttribute, false);
+			return;
+		}
+
 		const MPlug plug(fnNode.object(), fnAttribute.object());
 		bool isDefaultValue = false;
 		const std::wstring fqAttrName = ruleAttribute.fqName;
@@ -447,12 +453,8 @@ MStatus PRTModifierAction::updateUserSetAttributes(const MObject& node) {
 				break;
 		}
 
-		if (getAndResetForceDefault(fnNode, fnAttribute)) {
-			setIsUserSet(fnNode, fnAttribute, false);
-		}
-		else if (!isDefaultValue){
+		if (!isDefaultValue)
 			setIsUserSet(fnNode, fnAttribute, true);
-		}
 	};
 
 	iterateThroughAttributesAndApply(node, mRuleAttributes, updateUserSetAttribute);

--- a/src/serlio/modifiers/PRTModifierNode.cpp
+++ b/src/serlio/modifiers/PRTModifierNode.cpp
@@ -94,7 +94,7 @@ MStatus PRTModifierNode::compute(const MPlug& plug, MDataBlock& data) {
 			MDataHandle currentRulePkgData = data.inputValue(currentRulePkg, &status);
 			MCheckStatus(status, "ERROR getting currentRulePkg");
 
-			const bool ruleFileWasChanged = rulePkgData.asString() != currentRulePkgData.asString();
+			const bool ruleFileWasChanged = (rulePkgData.asString() != currentRulePkgData.asString());
 
 			// Copy the inMesh to the outMesh, so you can
 			// perform operations directly on outMesh

--- a/src/serlio/modifiers/PRTModifierNode.cpp
+++ b/src/serlio/modifiers/PRTModifierNode.cpp
@@ -94,6 +94,8 @@ MStatus PRTModifierNode::compute(const MPlug& plug, MDataBlock& data) {
 			MDataHandle currentRulePkgData = data.inputValue(currentRulePkg, &status);
 			MCheckStatus(status, "ERROR getting currentRulePkg");
 
+			const bool ruleFileWasChanged = rulePkgData.asString() != currentRulePkgData.asString();
+
 			// Copy the inMesh to the outMesh, so you can
 			// perform operations directly on outMesh
 			//
@@ -104,14 +106,14 @@ MStatus PRTModifierNode::compute(const MPlug& plug, MDataBlock& data) {
 			// Set the mesh object and component List on the factory
 			fPRTModifierAction.setMesh(iMesh, oMesh);
 
-			fPRTModifierAction.updateUserSetAttributes(thisMObject());
+			if (!ruleFileWasChanged)
+				fPRTModifierAction.updateUserSetAttributes(thisMObject());
 
 			MDataHandle randomSeed = data.inputValue(mRandomSeed, &status);
 			fPRTModifierAction.setRandomSeed(randomSeed.asInt());
 
-			if (rulePkgData.asString() != currentRulePkgData.asString()) {
+			if (ruleFileWasChanged)
 				fPRTModifierAction.updateRuleFiles(thisMObject(), rulePkgData.asString());
-			}
 
 			status = fPRTModifierAction.fillAttributesFromNode(thisMObject());
 			if (status != MStatus::kSuccess)


### PR DESCRIPTION
- generate dynamic default values that depend on user set attributes
- add functionality to query dynamic default values for enums 
- minor improvements for setting attribute values
This PR depends on changes made in [PR 103](https://github.com/Esri/serlio/pull/103) and [PR 104](https://github.com/Esri/serlio/pull/104), therefore these should be reviewed first. 
The first actual commit for this PR is b9b29f3