### PR TITLE
Reserve correct length for uv arrays in SerializedGeometry

### DIFF
--- a/src/codec/encoder/MayaEncoder.cpp
+++ b/src/codec/encoder/MayaEncoder.cpp
@@ -87,7 +87,7 @@ struct SerializedGeometry {
 		vertexIndices.reserve(numIndices);
 		normalIndices.reserve(numIndices);
 
-		assert(numUvCounts.size() == uvSets);
+		assert(numUvs.size() == uvSets);
 		assert(numUvCounts.size() == uvSets);
 		assert(numUvIndices.size() == uvSets);
 

--- a/src/codec/encoder/MayaEncoder.cpp
+++ b/src/codec/encoder/MayaEncoder.cpp
@@ -589,7 +589,7 @@ void MayaEncoder::convertGeometry(const prtx::InitialShape& initialShape,
                                   const prtx::EncodePreparator::InstanceVector& instances, IMayaCallbacks* cb) {
 	if (instances.empty())
 		return;
-	
+
 	const bool emitMaterials = getOptions()->getBool(EO_EMIT_MATERIALS);
 	const bool emitReports = getOptions()->getBool(EO_EMIT_REPORTS);
 


### PR DESCRIPTION
This optimization reduces the amount of necessary memory allocations for filling the uv arrays in the serialized geometry.