### PR TITLE
Update prt version to 2.6

### DIFF
--- a/src/common.cmake
+++ b/src/common.cmake
@@ -42,7 +42,7 @@ if (NOT prt_DIR)
 		set(PRT_TC "gcc93")
 	endif ()
 
-	set(PRT_VERSION "2.5.7799")
+	set(PRT_VERSION "2.6.8135")
 	set(PRT_CLS "${PRT_OS}-${PRT_TC}-x86_64-rel-opt")
 	set(PRT_URL "https://github.com/esri/cityengine-sdk/releases/download/${PRT_VERSION}/esri_ce_sdk-${PRT_VERSION}-${PRT_CLS}.zip")
 


### PR DESCRIPTION
- upgrade prt version to 2.6
- tested with chinese (non-ascii) encoded .obj files