### PR TITLE
Cknieling/fix maya2022 log

### DIFF
--- a/src/serlio/PRTContext.cpp
+++ b/src/serlio/PRTContext.cpp
@@ -19,8 +19,6 @@
 
 #include "PRTContext.h"
 
-#include "utils/LogHandler.h"
-
 #include <mutex>
 
 namespace {
@@ -48,8 +46,8 @@ PRTContext& PRTContext::get() {
 
 PRTContext::PRTContext(const std::vector<std::wstring>& addExtDirs) : mPluginRootPath(prtu::getPluginRoot()) {
 	if (ENABLE_LOG_CONSOLE) {
-		theLogHandler = prt::ConsoleLogHandler::create(prt::LogHandler::ALL, prt::LogHandler::ALL_COUNT);
-		prt::addLogHandler(theLogHandler);
+		theLogHandler = std::make_unique<logging::LogHandler>();
+		prt::addLogHandler(theLogHandler.get());
 	}
 
 	if (ENABLE_LOG_FILE) {
@@ -98,9 +96,7 @@ PRTContext::~PRTContext() {
 	thePRT.reset();
 
 	if (ENABLE_LOG_CONSOLE && (theLogHandler != nullptr)) {
-		prt::removeLogHandler(theLogHandler);
-		theLogHandler->destroy();
-		theLogHandler = nullptr;
+		prt::removeLogHandler(theLogHandler.get());
 	}
 
 	if (ENABLE_LOG_FILE && (theFileLogHandler != nullptr)) {

--- a/src/serlio/PRTContext.h
+++ b/src/serlio/PRTContext.h
@@ -21,6 +21,7 @@
 
 #include "serlioPlugin.h"
 
+#include "utils/LogHandler.h"
 #include "utils/ResolveMapCache.h"
 #include "utils/Utilities.h"
 
@@ -47,7 +48,7 @@ struct SRL_TEST_EXPORTS_API PRTContext final {
 	const std::filesystem::path mPluginRootPath; // the path where serlio dso resides
 	ObjectUPtr thePRT;
 	CacheObjectUPtr theCache;
-	prt::ConsoleLogHandler* theLogHandler = nullptr;
+	logging::LogHandlerUPtr theLogHandler;
 	prt::FileLogHandler* theFileLogHandler = nullptr;
 	ResolveMapCacheUPtr mResolveMapCache;
 };

--- a/src/serlio/utils/LogHandler.h
+++ b/src/serlio/utils/LogHandler.h
@@ -101,10 +101,8 @@ struct PRTLogger : Logger {
 
 class LogHandler : public prt::LogHandler {
 public:
-	explicit LogHandler(const std::wstring& name) : mName(name) {}
-
 	void handleLogEvent(const wchar_t* msg, prt::LogLevel) override {
-		std::wcout << L"[" << mName << L"] " << msg << std::endl;
+		std::cout << prtu::toOSNarrowFromUTF16(msg) << std::endl;
 	}
 
 	const prt::LogLevel* getLevels(size_t* count) override {
@@ -116,13 +114,6 @@ public:
 		*dateTime = true;
 		*level = true;
 	}
-
-	void setName(const std::wstring& n) {
-		mName = n;
-	}
-
-private:
-	std::wstring mName;
 };
 
 using LogHandlerPtr = std::unique_ptr<LogHandler>;

--- a/src/serlio/utils/LogHandler.h
+++ b/src/serlio/utils/LogHandler.h
@@ -84,7 +84,7 @@ public:
 	}
 };
 
-using LogHandlerPtr = std::unique_ptr<LogHandler>;
+using LogHandlerUPtr = std::unique_ptr<LogHandler>;
 
 } // namespace logging
 

--- a/src/serlio/utils/LogHandler.h
+++ b/src/serlio/utils/LogHandler.h
@@ -35,38 +35,6 @@
 namespace logging {
 
 struct Logger {};
-
-const std::string LEVELS[] = {"trace", "debug", "info", "warning", "error", "fatal"};
-const std::wstring WLEVELS[] = {L"trace", L"debug", L"info", L"warning", L"error", L"fatal"};
-
-// log to std streams
-template <prt::LogLevel L>
-struct StreamLogger : Logger {
-	explicit StreamLogger(std::wostream& out = std::wcout) : Logger(), mOut(out) {
-		mOut << prefix();
-	}
-	virtual ~StreamLogger() {
-		mOut << std::endl;
-	}
-	StreamLogger<L>& operator<<(std::wostream& (*x)(std::wostream&)) {
-		mOut << x;
-		return *this;
-	}
-	StreamLogger<L>& operator<<(const std::string& x) {
-		std::copy(x.begin(), x.end(), std::ostream_iterator<char, wchar_t>(mOut));
-		return *this;
-	}
-	template <typename T>
-	StreamLogger<L>& operator<<(const T& x) {
-		mOut << x;
-		return *this;
-	}
-	static std::wstring prefix() {
-		return L"[" + WLEVELS[L] + L"] ";
-	}
-	std::wostream& mOut;
-};
-
 // log through the prt logger
 template <prt::LogLevel L>
 struct PRTLogger : Logger {


### PR DESCRIPTION
- fix logs to the output window 
  - only writing to std::cout now (writing to wout with maya2022 is broken)
  - only support narrow encoded output stream (seems to be a maya 2022 limitation)