### PR TITLE
Always add keys from textures and texturearrays to the attributemap...

### DIFF
--- a/src/codec/encoder/MayaEncoder.cpp
+++ b/src/codec/encoder/MayaEncoder.cpp
@@ -316,9 +316,7 @@ void convertMaterialToAttributeMap(prtx::PRTUtils::AttributeMapBuilderPtr& aBuil
 			case prtx::Material::PT_TEXTURE: {
 				const auto& t = prtxAttr.getTexture(key);
 				const std::wstring p = getTexturePath(t, cb, cache);
-				if (!p.empty()) {
-					aBuilder->setString(key.c_str(), p.c_str());
-				}
+				aBuilder->setString(key.c_str(), p.c_str());
 				break;
 			}
 
@@ -334,10 +332,8 @@ void convertMaterialToAttributeMap(prtx::PRTUtils::AttributeMapBuilderPtr& aBuil
 						texPaths.push_back(texPath);
 				}
 
-				if (!texPaths.empty()) {
-					const std::vector<const wchar_t*> pTexPaths = toPtrVec(texPaths);
-					aBuilder->setStringArray(key.c_str(), pTexPaths.data(), pTexPaths.size());
-				}
+				const std::vector<const wchar_t*> pTexPaths = toPtrVec(texPaths);
+				aBuilder->setStringArray(key.c_str(), pTexPaths.data(), pTexPaths.size());
 
 				break;
 			}


### PR DESCRIPTION
- fix missing texture bug, caused by missing key values in the material attribute map