### PR TITLE
Fix transparency in serlio stingray shader

### DIFF
--- a/src/serlio/materials/StingrayMaterialNode.cpp
+++ b/src/serlio/materials/StingrayMaterialNode.cpp
@@ -99,7 +99,7 @@ void appendToMaterialScriptBuilder(MELScriptBuilder& sb, const MaterialInfo& mat
 	sb.addCmdLine(MEL_VAR_SHADING_NODE_INDEX.mel() + L" = `shaderfx -sfxnode " + MEL_VAR_SHADER_NODE.mel() +
 	              L" -getNodeIDByName " + nodeIDName.mel() + L"`;");
 
-	const std::wstring blendMode = (matInfo.opacityMap.empty() && (matInfo.opacity >= 1.0)) ? L"0" : L"1";
+	const std::wstring blendMode = (matInfo.opacityMap.empty() && (matInfo.opacity >= 1.0)) ? L"0" : L"2";
 	sb.addCmdLine(L"shaderfx -sfxnode " + MEL_VAR_SHADER_NODE.mel() + L" -edit_stringlist " +
 	              MEL_VAR_SHADING_NODE_INDEX.mel() + L" blendmode " + blendMode + L";");
 

--- a/src/serlio/shaders/serlioShaderStingray.sfx
+++ b/src/serlio/shaders/serlioShaderStingray.sfx
@@ -135,7 +135,7 @@ NumberOfNodes=81
 	posx=1 v=2003 1636.499512
 	posy=1 v=2003 871.666687
 	normalspace=2 e=0 v=5012 1
-	blendmode=2 e=0 v=5012 1
+	blendmode=2 e=0 v=5012 2
 	group=-1
 	ISC=13
 		SVT=5022 3002 1 0 0 
@@ -2231,7 +2231,7 @@ nodes = [
 		} 
 		id = "abbaabba-abba-abba-abba-abbaabbaabb9" 
 		options = [ 
-			"dd7fcf97-0627-48ab-b29a-95b5685bb123"
+			"3b55d6c6-4398-4dbc-b9ef-570aff8696ae"
 			"2b136447-676e-4943-997b-04a28ae68497"
 		] 
 		position = [ 


### PR DESCRIPTION
- Using the wrong blend mode in our material shader caused artifacts on materials that were supposed to be completely transparent.
- Now using the correct blend mode. 