### PR TITLE
Cknieling/updatable dynamic enums

### DIFF
--- a/src/serlio/modifiers/PRTModifierAction.cpp
+++ b/src/serlio/modifiers/PRTModifierAction.cpp
@@ -590,15 +590,12 @@ MStatus PRTModifierAction::updateUI(const MObject& node, MDataHandle& cgacProble
 
 				short enumVal;
 				MCHECK(plug.getValue(enumVal));
-				const auto newEnumInfo =
-				        currEnum.updateOptions(node, mRuleAttributes, *defaultAttributeValues, enumVal);
-				const bool hasNewEnumOptions = newEnumInfo.first;
-				enumVal = newEnumInfo.second;
+				enumVal = currEnum.updateOptions(node, mRuleAttributes, *defaultAttributeValues, enumVal);
 
 				const short defEnumVal = currEnum.getDefaultEnumValue(*defaultAttributeValues, ruleAttribute);
 
 				const bool isDefaultValue = (defEnumVal == enumVal);
-				if (hasNewEnumOptions || (!getIsUserSet(fnNode, fnAttribute) && !isDefaultValue))
+				if (!getIsUserSet(fnNode, fnAttribute) && !isDefaultValue)
 					plug.setShort(defEnumVal);
 				break;
 			}

--- a/src/serlio/modifiers/PRTModifierEnum.cpp
+++ b/src/serlio/modifiers/PRTModifierEnum.cpp
@@ -35,9 +35,8 @@ constexpr const wchar_t* VALUES_ATTR_KEY = L"valuesAttr";
 
 // This function updates all enum options and returns a pair, where the first argument indicates if the options have
 // changed and the second argument corresponds to the new index of the currently selected item
-std::pair<bool, short> PRTModifierEnum::updateOptions(const MObject& node, const RuleAttributeMap& mRuleAttributes,
-                                                      const prt::AttributeMap& defaultAttributeValues,
-                                                      short selectedEnumIdx) {
+short PRTModifierEnum::updateOptions(const MObject& node, const RuleAttributeMap& mRuleAttributes,
+                                     const prt::AttributeMap& defaultAttributeValues, short selectedEnumIdx) {
 	const MString fullAttrName = mAttr.name();
 	const auto ruleAttrIt = mRuleAttributes.find(fullAttrName.asWChar());
 	assert(ruleAttrIt != mRuleAttributes.end()); // Rule not found
@@ -48,7 +47,7 @@ std::pair<bool, short> PRTModifierEnum::updateOptions(const MObject& node, const
 	const bool hasNewCustomDefaultValue = updateCustomEnumValue(ruleAttr, defaultAttributeValues);
 
 	if ((newEnumOptions == mEnumOptions) && !hasNewCustomDefaultValue)
-		return std::make_pair(false, selectedEnumIdx);
+		return selectedEnumIdx;
 
 	const std::wstring oldSelectedOption = mAttr.fieldName(selectedEnumIdx).asWChar();
 
@@ -73,7 +72,7 @@ std::pair<bool, short> PRTModifierEnum::updateOptions(const MObject& node, const
 		MCHECK(mu::setEnumOptions(node, mAttr, mEnumOptions, {}));
 	}
 
-	return std::make_pair(true, newSelectedEnumIdx);
+	return newSelectedEnumIdx;
 }
 
 bool PRTModifierEnum::isDynamic() const {

--- a/src/serlio/modifiers/PRTModifierEnum.h
+++ b/src/serlio/modifiers/PRTModifierEnum.h
@@ -34,8 +34,8 @@ public:
 	PRTModifierEnum() = default;
 
 	MStatus fill(const prt::Annotation* annot);
-	std::pair<bool, short> updateOptions(const MObject& node, const RuleAttributeMap& ruleAttributes,
-	                                     const prt::AttributeMap& defaultAttributeValues, short selectedEnumIdx = 0);
+	short updateOptions(const MObject& node, const RuleAttributeMap& ruleAttributes,
+	                    const prt::AttributeMap& defaultAttributeValues, short selectedEnumIdx = 0);
 
 	bool isDynamic() const;
 	size_t getOptionIndex(const std::wstring& optionName) const;

--- a/src/serlio/scripts/AEserlioTemplate.mel
+++ b/src/serlio/scripts/AEserlioTemplate.mel
@@ -184,12 +184,7 @@ global proc prtForceDefault(string $attr){
 	setAttr ($attr + "_force_default") true;
 }
 
-global proc redrawEnum(string $attr, string $oldEnumOptions){
-	//only redraw the enum if options changed
-	string $newEnumOptions = `addAttr -q -en $attr`;
-	if($newEnumOptions == $oldEnumOptions)
-		return;
-
+global proc redrawEnum(string $attr){
 	setUITemplate -pst attributeEditorTemplate;
 	string $control = prtControlName($attr);
 	
@@ -208,8 +203,6 @@ global proc redrawEnum(string $attr, string $oldEnumOptions){
 
 	string $changeCommand = "prtUpdateEditHighlights " + $attr;
 	scriptJob -p $control -ac  ($attr + "_user_set") $changeCommand;
-	$changeEnumSelectionCommand = "redrawEnum " + $attr + " \"" + $newEnumOptions + "\"";
-	scriptJob -p $control -ac $attr $changeEnumSelectionCommand;
 	prtUpdateEditHighlights($attr);
 }
 
@@ -234,9 +227,6 @@ global proc prtAttributeControl(string $attr, string $varname){
 	} else if (prtIsEnumAttr($attr)){
 		attrEnumOptionMenuGrp -label $label -attribute $attr $control;
 		string $enumOptions = `addAttr -q -en $attr`;
-
-		$changeEnumSelectionCommand = "redrawEnum " + $attr + " \"" + $enumOptions + "\"";
-		scriptJob -p $control -ac $attr $changeEnumSelectionCommand;
 	} else {
 		attrControlGrp -label $label -attribute $attr $control;
 	}
@@ -272,10 +262,6 @@ global proc prtAttributeControlReplace(string $attr, string $varname){
 		} else if (prtIsEnumAttr($attr)){
 			attrEnumOptionMenuGrp -edit -attribute $attr $control;
 			connectControl $control $attr;
-
-			string $enumOptions = `addAttr -q -en $attr`;
-			$changeEnumSelectionCommand = "redrawEnum " + $attr + " \"" + $enumOptions + "\"";
-			scriptJob -p $control -ac $attr $changeEnumSelectionCommand;
 		} else {
 			attrControlGrp -edit -attribute $attr $control;
 			connectControl $control $attr;

--- a/src/serlio/utils/MELScriptBuilder.cpp
+++ b/src/serlio/utils/MELScriptBuilder.cpp
@@ -118,6 +118,8 @@ void MELScriptBuilder::setAttrEnumOptions(const MELVariable& node, const std::ws
 
 	commandStream << "addAttr -e -en " << MELStringLiteral(enumString).mel() << " "
 	              << composeAttributeExpression(node, attribute) << ";\n";
+	commandStream << "if (`exists redrawEnum`)\n";
+	commandStream << "\tredrawEnum(" << composeAttributeExpression(node, attribute) << ");\n";
 }
 
 void MELScriptBuilder::connectAttr(const MELVariable& srcNode, const std::wstring& srcAttr, const MELVariable& dstNode,


### PR DESCRIPTION
- fixed a bug where enum options would disappear, when reloading a rule file
- redraw enum call is directly called through API instead of a scriptjob