### PR TITLE
Fix a typo in the maya example code

### DIFF
--- a/src/serlio/modifiers/polyModifier/polyModifierCmd.cpp
+++ b/src/serlio/modifiers/polyModifier/polyModifierCmd.cpp
@@ -693,7 +693,7 @@ MStatus polyModifierCmd::processTweaks( modifyPolyData& data )
 			{
 				for( i = 0; i < numTweaks; i++ )
 				{
-					tweak = meshTweakPlug.elementByLogicalIndex( fTweakIndexArray[i] );
+					tweak = upstreamTweakPlug.elementByLogicalIndex( fTweakIndexArray[i] );
 					tweak.setValue( nullVector );
 				}
 			}


### PR DESCRIPTION
Fixed issue in maya example code for modifier nodes that caused duplicate vertex tweaks when working on a mesh without construction history. 