### PR TITLE
CE-11817: Add missing build dir required by CLI cleanup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,9 +130,7 @@ def taskBuildCMake(cfg, target){
 	cepl.cleanCurrentDir()
 	unstash(name: SOURCE_STASH)
 	deps.each { d -> papl.fetchDependency(d, cfg) }
-	papl.jpe.dir(path: 'build') {
-		papl.runCMakeBuild(SOURCES, target, cfg, defs)
-	}
+	papl.runCMakeBuild(SOURCES, 'build', target, cfg, defs)
 }
 
 def taskBuildSerlio(cfg) {


### PR DESCRIPTION
See https://devtopia.esri.com/Zurich-R-D-Center/zrh-jenkins/pull/139